### PR TITLE
Mobile Release v1.0.0

### DIFF
--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-aztec",
-	"version": "1.96.1",
+	"version": "1.97.0",
 	"description": "Aztec view for react-native.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-bridge",
-	"version": "1.96.1",
+	"version": "1.97.0",
 	"description": "Native bridge library used to integrate the block editor into a native App.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -12,9 +12,9 @@ For each user feature we should also add a importance categorization label  to i
 ## Unreleased
 
 ## 1.97.0
-- [**] [iOS] Fix dictation regression, in which typing/dictating at the same time caused content loss. [#49452]
-- [*] [internal] Upgrade compile and target sdk version to Android API 33 [#50731]
-- [*] Display lock icon in disabled state of `Cell` component [#50907]
+-   [**] [iOS] Fix dictation regression, in which typing/dictating at the same time caused content loss. [#49452]
+-   [*] [internal] Upgrade compile and target sdk version to Android API 33 [#50731]
+-   [*] Display lock icon in disabled state of `Cell` component [#50907]
 
 ## 1.96.1
 -   [**] Fix Android-only issue related to block toolbar not being displayed on some blocks in UBE [#51131]

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -12,7 +12,9 @@ For each user feature we should also add a importance categorization label  to i
 ## Unreleased
 
 ## 1.97.0
--   [*] [internal] Upgrade compile and target sdk version to Android API 33 [#50731]
+- [**] [iOS] Fix dictation regression, in which typing/dictating at the same time caused content loss. [#49452]
+- [*] [internal] Upgrade compile and target sdk version to Android API 33 [#50731]
+- [*] Display lock icon in disabled state of `Cell` component [#50907]
 
 ## 1.96.1
 -   [**] Fix Android-only issue related to block toolbar not being displayed on some blocks in UBE [#51131]
@@ -23,7 +25,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [**] Fix undo/redo history when inserting a link configured to open in a new tab [#50460]
 -   [*] [List block] Fix an issue when merging a list item into a Paragraph would remove its nested list items. [#50701]
 
--   [**] [iOS] Fix dictation regression, in which typing/dictating at the same time caused content loss. [#49452]
+
 
 ## 1.95.0
 -   [*] Fix crash when trying to convert to regular blocks an undefined/deleted reusable block [#50475]

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,8 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+
+## 1.97.0
 -   [*] [internal] Upgrade compile and target sdk version to Android API 33 [#50731]
 
 ## 1.96.1

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.69.4)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - Gutenberg (1.96.1):
+  - Gutenberg (1.97.0):
     - React-Core (= 0.69.4)
     - React-CoreModules (= 0.69.4)
     - React-RCTImage (= 0.69.4)
@@ -360,7 +360,7 @@ PODS:
     - React-Core
   - RNSVG (9.13.6):
     - React-Core
-  - RNTAztecView (1.96.1):
+  - RNTAztecView (1.97.0):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.8)
   - SDWebImage (5.11.1):
@@ -540,7 +540,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 2ff441cbe6e58c1778d8a5cf3311831a6a8c0809
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
-  Gutenberg: 5cd4d25aa41b725c7802394e4f3b8eeddf90f370
+  Gutenberg: 75e04d6a42ecfb201115f1ccbb066680915a35aa
   libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
   RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
   RCTRequired: bd9d2ab0fda10171fcbcf9ba61a7df4dc15a28f4
@@ -582,7 +582,7 @@ SPEC CHECKSUMS:
   RNReanimated: 5740ec9926f80bccd404bacd3e71108e87c94afa
   RNScreens: 953633729a42e23ad0c93574d676b361e3335e8b
   RNSVG: 36a7359c428dcb7c6bce1cc546fbfebe069809b0
-  RNTAztecView: 59e8ceb3dd9473ad7f1e6cca3232caf3cd620009
+  RNTAztecView: 221ecdc2998b979bd0994b9100101ba755cbb1d8
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-editor",
-	"version": "1.96.1",
+	"version": "1.97.0",
 	"description": "Mobile WordPress gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Description
Release 1.0.0 of the react-native-editor and Gutenberg-Mobile.


For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/jhnstn/gutenberg-mobile/pull/19
